### PR TITLE
Fixed NullReferenceException

### DIFF
--- a/TSLint/ErrorListHelper.cs
+++ b/TSLint/ErrorListHelper.cs
@@ -21,16 +21,27 @@ namespace TSLint
 
         internal static void Suspend()
         {
-            ErrorListHelper._provider.SuspendRefresh();
+            if (ErrorListHelper._provider != null)
+            {
+                ErrorListHelper._provider.SuspendRefresh();
+            }
         }
 
         internal static void Resume()
         {
-            ErrorListHelper._provider.ResumeRefresh();
+            if (ErrorListHelper._provider != null)
+            {
+                ErrorListHelper._provider.ResumeRefresh();
+            }
         }
 
         internal static void RemoveAllForDocument(string name)
         {
+            if (ErrorListHelper._provider == null)
+            {
+                return;
+            }
+
             for (var i = ErrorListHelper._provider.Tasks.Count - 1; i >= 0; i--)
             {
                 var task = ErrorListHelper._provider.Tasks[i];
@@ -44,6 +55,11 @@ namespace TSLint
 
         internal static void Add(TsLintTag tag)
         {
+            if (ErrorListHelper._provider == null)
+            {
+                return;
+            }
+
             var error = new ErrorTask()
             {
                 ErrorCategory =
@@ -58,7 +74,8 @@ namespace TSLint
                 Text = tag.ToolTipContent.ToString(),
             };
 
-            error.Navigate += (s, e) => {
+            error.Navigate += (s, e) =>
+            {
                 var task = new Task()
                 {
                     Document = error.Document,


### PR DESCRIPTION
We're seeing **a lot** of NullReferenceExceptions from this extension that causes VS to crash and they come from calls made to `ErrorListHelper` in `TsLintTagger.OnViewClosed`. This PR should fix it.

If you have any questions, please let me know here or email me at madsk@microsoft.com.

Mads Kristensen
Visual Studio Extensibility
